### PR TITLE
Added analogReadSampleDelay

### DIFF
--- a/megaavr/cores/dxcore/ADC.h
+++ b/megaavr/cores/dxcore/ADC.h
@@ -1,0 +1,28 @@
+/*
+This header file is based on Josh Zimmerling's ADC.h header file
+https://github.com/jnbrauer/SER401-2022-Group39-Documentation/blob/main/ADC/ADC.h
+
+Also, this file will only use parts of Josh's header file for MALS-98 only.
+*/ 
+
+#ifndef ADC_H
+#define ADC_H
+
+#include <stdint.h>
+
+typedef struct ADCConfig_struct {
+    uint8_t convMode;    // 0 = single-ended, 1 = differential
+    uint8_t muxNeg;      // Differential mode negative pin
+    uint8_t resolution;  // ADC bit resolution
+    uint8_t prescaler;   // ADC clock prescaler
+    uint8_t sampleNum;   // Number of samples to accumulate - should define constants for these
+    uint8_t sampleDelay; // Delay in ADC clock cycles between samples during accumulation
+    uint8_t sampleLen;   // ADC sampling time in ADC clock cycles
+} ADCConfig;
+
+/*
+Specify the delay between samples
+*/
+void analogReadSampleDelay(uint8_t delay);
+
+#endif

--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -27,6 +27,8 @@
 #include "Arduino.h"
 #include <avr/pgmspace.h>
 
+#include "ADC.h"
+
 /* magic value passsed as the negative pin to tell the _analogReadEnh() (which implements both th new ADC
  * functions) to tell them what kind of mode it's to be used in. This also helps with providing useful and accurate
  * error messages and codes at runtime, since we have no other way to report such.                                 */
@@ -871,3 +873,19 @@ uint8_t digitalPinToTimerNow(uint8_t p) {
     }
   }
 */
+
+// MALS-98
+void analogReadSampleDelay(uint8_t delay) {
+  if (~(ADC0.COMMAND & ADC_STCONV_bm) && delay >= 0 && delay <= 15) {
+    ADCConfig.sampleDelay = delay;
+    ADC0.CTRLD |= delay;
+  }
+}
+
+void analogReadSampleDelay(ADC_SAMPDLY_t delay) {
+  uint8_t int_delay = (uint8_t) delay;
+  if (~(ADC0.COMMAND & ADC_STCONV_bm) && int_delay >= 0 && int_delay <= 15) {
+    ADCConfig.sampleDelay = int_delay;
+    ADC0.CTRLD = delay;
+  }
+}


### PR DESCRIPTION
Made a rough draft of analogReadSampleDelay which sets the delay in between samples. It can use either a uint8_t or ADC_SAMPDLY_t parameter.