### PR TITLE
Add analogReadEnableDifferential

### DIFF
--- a/megaavr/cores/dxcore/ADC.h
+++ b/megaavr/cores/dxcore/ADC.h
@@ -1,7 +1,9 @@
 #ifndef ADC_H
 #define ADC_H
 
-#include <stdint.h>
+#ifdef __cplusplus
+extern "C"{
+#endif
 
 //////////////////////////////////////////////////////////////
 //                     General ADC API                      //
@@ -54,5 +56,9 @@ void analogReadEnableSingleEnded();
 Enables differential mode
 */
 void analogReadEnableDifferential(uint8_t negPin);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/megaavr/cores/dxcore/Arduino.h
+++ b/megaavr/cores/dxcore/Arduino.h
@@ -30,6 +30,7 @@
 #include "UART_constants.h"
 #include "core_devices.h"
 #include "device_timer_pins.h"
+#include "ADC.h"
 /* Gives names to all the timer pins - relies on core_devices.h being included first.*/
 /* These names look like:
  * PIN_TCD0_WOC_DEFAULT

--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -160,6 +160,14 @@ int16_t analogRead(uint8_t pin) {
   return ADC0.RES;
 }
 
+void analogReadEnableDifferential(uint8_t negPin) {
+  check_valid_negative_pin(pin);
+
+  while (ADC0.COMMAND & 1);
+
+  ADC0.CTRLA |= 1 << 5;
+  ADC0.MUXNEG = negPin;
+}
 
 inline __attribute__((always_inline)) void check_valid_negative_pin(uint8_t pin) {
   if(__builtin_constant_p(pin)) {

--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -160,15 +160,6 @@ int16_t analogRead(uint8_t pin) {
   return ADC0.RES;
 }
 
-void analogReadEnableDifferential(uint8_t negPin) {
-  check_valid_negative_pin(pin);
-
-  while (ADC0.COMMAND & 1);
-
-  ADC0.CTRLA |= 1 << 5;
-  ADC0.MUXNEG = negPin;
-}
-
 inline __attribute__((always_inline)) void check_valid_negative_pin(uint8_t pin) {
   if(__builtin_constant_p(pin)) {
     if (pin < 0x80) {
@@ -880,11 +871,19 @@ uint8_t digitalPinToTimerNow(uint8_t p) {
   }
 */
 
-// MALS-98
 void analogReadSampleDelay(uint8_t delay) {
   while (ADC0.COMMAND & ADC_STCONV_bm) {}
   if (delay <= 15) {
-    ADC0.CTRLD &= 0b11110000; // After: ADC0.CTRLD = 0b11000000
-    ADC0.CTRLD |= delay; // After: ADC0.CTRLD = 0b11000110
+    ADC0.CTRLD &= 0b11110000;
+    ADC0.CTRLD |= delay;
   }
+}
+
+void analogReadEnableDifferential(uint8_t negPin) {
+  check_valid_negative_pin(negPin);
+
+  while (ADC0.COMMAND & ADC_STCONV_bm);
+
+  ADC0.CTRLA |= ADC_CONVMODE_bm;
+  ADC0.MUXNEG = negPin;
 }


### PR DESCRIPTION
### Linked Jira Issue:
https://ser401-2022-group39.atlassian.net/browse/MALS-95

### Description of Changes:
Added analogReadEnableDifferential implementation and updated header files to include ADC functions with Arduino library correctly. 

### Acceptance Criteria:
- [x] AC 1: Changes CONVMODE register on ADC to operate in differential mode
- [x] AC 2: Differential mode uses correct pins assigned to POSMUX and NEGMUX
- [x] AC 3: Function blocks modifying register while ADC conversion is active with STCONV