### PR TITLE
Implement analogReadEnableSingleEnded

### DIFF
--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -887,3 +887,9 @@ void analogReadEnableDifferential(uint8_t negPin) {
   ADC0.CTRLA |= ADC_CONVMODE_bm;
   ADC0.MUXNEG = negPin;
 }
+
+void analogReadEnableSingleEnded() {
+  while (ADC0.COMMAND & ADC_STCONV_bm);
+
+  ADC0.CTRLA &= ~ADC_CONVMODE_bm;
+}


### PR DESCRIPTION
Linked Jira Issue:
https://ser401-2022-group39.atlassian.net/browse/MALS-94

Description of Changes:
Implement function for switching ADC to single-ended conversion mode.

Acceptance Criteria:
[x] AC 1: Changes CONVMODE register on ADC to operate in single-ended mode
[x] AC 2: Uses correct input pin assigned to POSMUX
[x] AC 3: Function blocks modifying register while ADC conversion is active with STCONV