### PR TITLE
Remove redundant analogReadSampleLen

### DIFF
--- a/megaavr/cores/dxcore/ADC.h
+++ b/megaavr/cores/dxcore/ADC.h
@@ -1,7 +1,9 @@
 #ifndef ADC_H
 #define ADC_H
 
-#include <stdint.h>
+#ifdef __cplusplus
+extern "C"{
+#endif
 
 //////////////////////////////////////////////////////////////
 //                     General ADC API                      //
@@ -54,5 +56,9 @@ void analogReadEnableSingleEnded();
 Enables differential mode
 */
 void analogReadEnableDifferential(uint8_t negPin);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/megaavr/cores/dxcore/ADC.h
+++ b/megaavr/cores/dxcore/ADC.h
@@ -1,3 +1,8 @@
+#ifndef ADC_H
+#define ADC_H
+
+#include <stdint.h>
+
 //////////////////////////////////////////////////////////////
 //                     General ADC API                      //
 //////////////////////////////////////////////////////////////
@@ -18,7 +23,7 @@ typedef struct ADCConfig_struct {
 /*
 Sets the registers to fit the passed in configuration
 */
-void analogReadConfig(ADCConfig config)
+void analogReadConfig(ADCConfig config);
 
 /*
 Specify an accumulation amount
@@ -28,12 +33,12 @@ void analogReadSampleNum(uint8_t numSamples);
 /*
 Specify the delay between samples
 */
-void analogReadSampleDelay(uint8_t delay)
+void analogReadSampleDelay(uint8_t delay);
 
 /*
 Specify the length of each sample
 */
-void analogReadSampleLen(uint8_t len)
+void analogReadSampleLen(uint8_t len);
 
 /*
 Set the prescalaer
@@ -49,3 +54,5 @@ void analogReadEnableSingleEnded();
 Enables differential mode
 */
 void analogReadEnableDifferential(uint8_t negPin);
+
+#endif

--- a/megaavr/cores/dxcore/ADC.h
+++ b/megaavr/cores/dxcore/ADC.h
@@ -1,0 +1,51 @@
+//////////////////////////////////////////////////////////////
+//                     General ADC API                      //
+//////////////////////////////////////////////////////////////
+
+/*
+Structure used for the ADC configuration
+*/
+typedef struct ADCConfig_struct {
+    uint8_t convMode;    // 0 = single-ended, 1 = differential
+    uint8_t muxNeg;      // Differential mode negative pin
+    uint8_t resolution;  // ADC bit resolution
+    uint8_t prescaler;   // ADC clock prescaler
+    uint8_t sampleNum;   // Number of samples to accumulate - should define constants for these
+    uint8_t sampleDelay; // Delay in ADC clock cycles between samples during accumulation
+    uint8_t sampleLen;   // ADC sampling time in ADC clock cycles
+} ADCConfig;
+
+/*
+Sets the registers to fit the passed in configuration
+*/
+void analogReadConfig(ADCConfig config)
+
+/*
+Specify an accumulation amount
+*/
+void analogReadSampleNum(uint8_t numSamples);
+
+/*
+Specify the delay between samples
+*/
+void analogReadSampleDelay(uint8_t delay)
+
+/*
+Specify the length of each sample
+*/
+void analogReadSampleLen(uint8_t len)
+
+/*
+Set the prescalaer
+*/
+void analogReadPrescaler(uint8_t prescaler);
+
+/*
+Enables single-ended mode
+*/
+void analogReadEnableSingleEnded();
+
+/*
+Enables differential mode
+*/
+void analogReadEnableDifferential(uint8_t negPin);

--- a/megaavr/cores/dxcore/Arduino.h
+++ b/megaavr/cores/dxcore/Arduino.h
@@ -30,6 +30,7 @@
 #include "UART_constants.h"
 #include "core_devices.h"
 #include "device_timer_pins.h"
+#include "ADC.h"
 /* Gives names to all the timer pins - relies on core_devices.h being included first.*/
 /* These names look like:
  * PIN_TCD0_WOC_DEFAULT

--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -871,3 +871,12 @@ uint8_t digitalPinToTimerNow(uint8_t p) {
     }
   }
 */
+
+// MALS-98
+void analogReadSampleDelay(uint8_t delay) {
+  while (ADC0.COMMAND & ADC_STCONV_bm) {}
+  if (delay <= 15) {
+    ADC0.CTRLD &= 0b11110000; // After: ADC0.CTRLD = 0b11000000
+    ADC0.CTRLD |= delay; // After: ADC0.CTRLD = 0b11000110
+  }
+}

--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -160,7 +160,6 @@ int16_t analogRead(uint8_t pin) {
   return ADC0.RES;
 }
 
-
 inline __attribute__((always_inline)) void check_valid_negative_pin(uint8_t pin) {
   if(__builtin_constant_p(pin)) {
     if (pin < 0x80) {
@@ -872,11 +871,19 @@ uint8_t digitalPinToTimerNow(uint8_t p) {
   }
 */
 
-// MALS-98
 void analogReadSampleDelay(uint8_t delay) {
   while (ADC0.COMMAND & ADC_STCONV_bm) {}
   if (delay <= 15) {
-    ADC0.CTRLD &= 0b11110000; // After: ADC0.CTRLD = 0b11000000
-    ADC0.CTRLD |= delay; // After: ADC0.CTRLD = 0b11000110
+    ADC0.CTRLD &= 0b11110000;
+    ADC0.CTRLD |= delay;
   }
+}
+
+void analogReadEnableDifferential(uint8_t negPin) {
+  check_valid_negative_pin(negPin);
+
+  while (ADC0.COMMAND & ADC_STCONV_bm);
+
+  ADC0.CTRLA |= ADC_CONVMODE_bm;
+  ADC0.MUXNEG = negPin;
 }


### PR DESCRIPTION
### Linked Jira Issue:
https://ser401-2022-group39.atlassian.net/browse/MALS-99

### Description of Changes:
`analogReadSampleLen(uint8_t len)` was removed from the `ADC.h` as it is already implemented as `analogSampleDuration(uint8_t dur)` in `wiring_analog.c`. 