### PR TITLE
Remove redundant analogReadSampleLen

### DIFF
--- a/megaavr/cores/dxcore/ADC.h
+++ b/megaavr/cores/dxcore/ADC.h
@@ -38,11 +38,6 @@ Specify the delay between samples
 void analogReadSampleDelay(uint8_t delay);
 
 /*
-Specify the length of each sample
-*/
-void analogReadSampleLen(uint8_t len);
-
-/*
 Set the prescalaer
 */
 void analogReadPrescaler(uint8_t prescaler);


### PR DESCRIPTION
### Linked Jira Issue:
https://ser401-2022-group39.atlassian.net/browse/MALS-99

### Description of Changes:
`analogReadSampleLen(uint8_t len)` was removed from the `ADC.h` as it is already implemented as `analogSampleDuration(uint8_t dur)` in `wiring_analog.c`. 