### PR TITLE
Implementing analogReadPrescaler

### DIFF
--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -936,48 +936,61 @@ void analogReadEnableSingleEnded() {
 void analogReadPrescaler(uint8_t prescaler) {
   while (ADC0.COMMAND & ADC_STCONV_bm);
 
-  ADC0.CTRLC &= 0b11110000;   //Setting prescaler to 2
   switch (prescaler) {
   case 2:
-    //Empty case so that 2 doesn't through an error
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV2_gc;
     break;
   case 4:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV4_gc;
     break;
   case 8:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV8_gc;
     break;
   case 12:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV12_gc;
     break;
   case 16:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV16_gc;
     break;
   case 20:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV20_gc;
     break;
   case 24:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV24_gc;
     break;
   case 28:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV28_gc;
     break;
   case 32:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV32_gc;
     break;
   case 48:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV48_gc;
     break;
   case 64:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV64_gc;
     break;
   case 96:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV96_gc;
      break;
   case 128:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV128_gc;
     break;
   case 256:
+    ADC0.CTRLC &= 0b11110000;   //Clearing out pre-existing prescaler
     ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV256_gc;
     break;
   default:

--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -891,9 +891,13 @@ void analogReadEnableDifferential(uint8_t negPin) {
 void analogReadSampleNum(uint8_t numSamples) {
   while (ADC0.COMMAND & ADC_STCONV_bm) {}
     ADC0.CTRLB &= 0b11111000;   //Setting accumulation to 0
+
     switch (numSamples) {
     case 0:
       //Empty case so that 0 doesn't through an error
+      break;
+    case 1:
+      //Does nothing since 1 result accumulated is no accumulation
       break;
     case 2:
       ADC0.CTRLB |= ADC_SAMPNUM_t::ADC_SAMPNUM_ACC2_gc;
@@ -917,14 +921,67 @@ void analogReadSampleNum(uint8_t numSamples) {
       ADC0.CTRLB |= ADC_SAMPNUM_t::ADC_SAMPNUM_ACC128_gc;
       break;
     default:
-        badArg("Unexpected value");
+      badArg("Unexpected value");
       break;
     }
-  }
 }
 
 void analogReadEnableSingleEnded() {
   while (ADC0.COMMAND & ADC_STCONV_bm);
 
   ADC0.CTRLA &= ~ADC_CONVMODE_bm;
+}
+
+//Assuming default of 2, can ask bob about this
+void analogReadPrescaler(uint8_t prescaler) {
+  while (ADC0.COMMAND & ADC_STCONV_bm);
+
+  ADC0.CTRLC &= 0b11110000;   //Setting prescaler to 2
+  switch (prescaler) {
+  case 2:
+    //Empty case so that 2 doesn't through an error
+    break;
+  case 4:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV4_gc;
+    break;
+  case 8:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV8_gc;
+    break;
+  case 12:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV12_gc;
+    break;
+  case 16:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV16_gc;
+    break;
+  case 20:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV20_gc;
+    break;
+  case 24:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV24_gc;
+    break;
+  case 28:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV28_gc;
+    break;
+  case 32:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV32_gc;
+    break;
+  case 48:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV48_gc;
+    break;
+  case 64:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV64_gc;
+    break;
+  case 96:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV96_gc;
+     break;
+  case 128:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV128_gc;
+    break;
+  case 256:
+    ADC0.CTRLC |= ADC_PRESC_t::ADC_PRESC_DIV256_gc;
+    break;
+  default:
+    badArg("Unexpected value");
+    break;
+  }
 }


### PR DESCRIPTION
Linked Jira Issue:
https://ser401-2022-group39.atlassian.net/browse/MALS-96

Description of Changes:
Created the function analogReadPrescalar and cleaned up analogReadSampleNum

Acceptance Criteria:
- [X] AC 1: Properly updates CTRLC register with named constant division factor on ADC
- [X] AC 2: Uses correct input pin assigned to PRESC 
- [X] AC 3: Function blocks modifying register while ADC conversion is active with STCONV