### PR TITLE
Create analogReadEnableSingleEnded test case sketch

### DIFF
--- a/megaavr/extras/testCases/analogReadEnableSingleEnded/analogReadEnableSingleEnded.ino
+++ b/megaavr/extras/testCases/analogReadEnableSingleEnded/analogReadEnableSingleEnded.ino
@@ -5,7 +5,7 @@
 
 void printConvModeBit() {
   uint8_t convMode = (ADC0.CTRLA & ADC_CONVMODE_bm) >> 5;
-  da_Serial.print("Conversion mode:");
+  da_Serial.print("Conversion mode: ");
   da_Serial.println(convMode);
 }
 
@@ -14,7 +14,7 @@ void sample() {
 
   da_Serial.println("begin:");
   for (sample_index = 0; sample_index < SAMPLE_NUMBER; sample_index++) {
-    adc_value = analogRead(POS_PIN);
+    adc_value = analogRead(INPUT_PIN);
 
     da_Serial.printf(" %d\t%d", sample_index, adc_value/4);
     da_Serial.println();
@@ -28,12 +28,14 @@ void setup() {
 }
 
 void loop() {
-  da_Serial.println("---------- Entering single-ended mode: ----------")
-  analogReadEnableSingleEnded();  
+  da_Serial.println("---------- Entering single-ended mode: ----------");
+  analogReadEnableSingleEnded();
+  printConvModeBit();
   sample();
 
-  da_Serial.println("---------- Entering differential mode: ----------")
+  da_Serial.println("---------- Entering differential mode: ----------");
   analogReadEnableDifferential(NEGATIVE_PIN);
+  printConvModeBit();
   sample();
 
   delay(5000);

--- a/megaavr/extras/testCases/analogReadEnableSingleEnded/analogReadEnableSingleEnded.ino
+++ b/megaavr/extras/testCases/analogReadEnableSingleEnded/analogReadEnableSingleEnded.ino
@@ -1,19 +1,40 @@
 #define da_Serial Serial1
 #define INPUT_PIN A0
 #define NEGATIVE_PIN A1
+#define SAMPLE_NUMBER 128
+
+void printConvModeBit() {
+  uint8_t convMode = (ADC0.CTRLA & ADC_CONVMODE_bm) >> 5;
+  da_Serial.print("Conversion mode:");
+  da_Serial.println(convMode);
+}
+
+void sample() {
+  int adc_value, sample_index;
+
+  da_Serial.println("begin:");
+  for (sample_index = 0; sample_index < SAMPLE_NUMBER; sample_index++) {
+    adc_value = analogRead(POS_PIN);
+
+    da_Serial.printf(" %d\t%d", sample_index, adc_value/4);
+    da_Serial.println();
+  }
+
+  da_Serial.println("end:\n\n");
+}
 
 void setup() {
   da_Serial.begin(38400);
 }
 
 void loop() {
+  da_Serial.println("---------- Entering single-ended mode: ----------")
   analogReadEnableSingleEnded();  
-  da_Serial.print("Single-ended reading: ")
-  da_Serial.println(analogRead(INPUT_PIN));
+  sample();
 
+  da_Serial.println("---------- Entering differential mode: ----------")
   analogReadEnableDifferential(NEGATIVE_PIN);
-  da_Serial.print("Differential reading: ")
-  da_Serial.println(analogRead(INPUT_PIN));
+  sample();
 
-  delay(1000);
+  delay(5000);
 }

--- a/megaavr/extras/testCases/analogReadEnableSingleEnded/analogReadEnableSingleEnded.ino
+++ b/megaavr/extras/testCases/analogReadEnableSingleEnded/analogReadEnableSingleEnded.ino
@@ -1,0 +1,19 @@
+#define da_Serial Serial1
+#define INPUT_PIN A0
+#define NEGATIVE_PIN A1
+
+void setup() {
+  da_Serial.begin(38400);
+}
+
+void loop() {
+  analogReadEnableSingleEnded();  
+  da_Serial.print("Single-ended reading: ")
+  da_Serial.println(analogRead(INPUT_PIN));
+
+  analogReadEnableDifferential(NEGATIVE_PIN);
+  da_Serial.print("Differential reading: ")
+  da_Serial.println(analogRead(INPUT_PIN));
+
+  delay(1000);
+}

--- a/megaavr/extras/testCases/analogReadEnableSingleEnded/analogReadEnableSingleEnded.ino
+++ b/megaavr/extras/testCases/analogReadEnableSingleEnded/analogReadEnableSingleEnded.ino
@@ -16,7 +16,7 @@ void sample() {
   for (sample_index = 0; sample_index < SAMPLE_NUMBER; sample_index++) {
     adc_value = analogRead(INPUT_PIN);
 
-    da_Serial.printf(" %d\t%d", sample_index, adc_value/4);
+    da_Serial.printf(" %d\t%d", sample_index, adc_value);
     da_Serial.println();
   }
 


### PR DESCRIPTION
### Linked Jira Issue:
https://ser401-2022-group39.atlassian.net/browse/MALS-106

### Description of Changes:
Create a test case sketch for `analogReadEnableSingleEnded`. This test will switch back and forth between single-ended and differential mode, each time printing the state of the conversion mode bit in the ADC CTRLA register and taking a series of analog readings.

### Acceptance Criteria:
- [x] AC1: A sketch has been created that can be used to validate analogReadEnableSingleEnded
