### PR TITLE
Mals 136 delay sleep RTC improvements

### DIFF
--- a/megaavr/cores/dxcore/LowPower.h
+++ b/megaavr/cores/dxcore/LowPower.h
@@ -116,4 +116,14 @@ brown-out scenario.
 */
 void bodSetDisabled();
 
+
+//////////////////////////////////////////////////////////////
+//                      RTC Utilities                       //
+//////////////////////////////////////////////////////////////
+typedef void (*voidFuncPtr)(void);
+
+void attachRTCCNTInterrupt(voidFuncPtr func);
+
+void detachRTCCNTInterrupt();
+
 #endif

--- a/megaavr/libraries/DxCore/examples/LowPower/delaySleep_user_callback/delaySleep_user_callback.ino
+++ b/megaavr/libraries/DxCore/examples/LowPower/delaySleep_user_callback/delaySleep_user_callback.ino
@@ -1,0 +1,14 @@
+void myFunction(){
+  Serial1.print("Got to the custom handler!\n\r");
+}
+
+void setup() {
+  Serial1.begin(9600);
+  // put your setup code here, to run once:
+  attachRTCCNTInterrupt(myFunction);
+}
+
+void loop() {
+  delay(2000);
+  delaySleep(2000);
+}


### PR DESCRIPTION
### Linked Jira Issue:
https://ser401-2022-group39.atlassian.net/browse/MALS-136

### Description of Changes:
Added the ability to register a custom callback/interrupt handler for the RTC. Since we use the RTC in delaySleep, we must define its ISR. However, since the ISR can only be defined one place, this leaves the user without the ability to use the RTC interrupt when DxCore is installed. With this change the user is now able to register a function which will be executed whenever the RTC interrupt is triggered, allowing them to use it how they want.

### Acceptance Criteria:
- [x] AC 1: The interrupt handler registration works as expected and a demo sketch is included.
