### PR TITLE
MALS-110-sleepUntilTWIMatch-testCase Finished

### DIFF
--- a/megaavr/extras/testCases/sleepUntilTWIMatch_testCase/masterTWIMatch_testCase/masterTWIMatch_testCase.ino
+++ b/megaavr/extras/testCases/sleepUntilTWIMatch_testCase/masterTWIMatch_testCase/masterTWIMatch_testCase.ino
@@ -1,0 +1,36 @@
+// Used master_write.ino from libraries\Wire\examples\master_write
+// in the DxCore package by MX682X for reference
+
+// Master is ATmega328P XPlained Mini board
+// Recommended baud for Serial is 57600
+
+// Automatic master idea from Jude Brauer
+#include <Wire.h>
+
+#define MasterSerial Serial
+
+unsigned long serialBaud = 57600;
+uint8_t twiAddress = 0x08;
+int delayTime = 2000;
+
+void setup() {
+  MasterSerial.begin(serialBaud);
+  Wire.begin();
+}
+
+void loop() {
+  sendDataWire(twiAddress);
+  delay(delayTime);
+}
+
+void sendDataWire(uint8_t twiAddress) {
+  MasterSerial.write("Sending message to slave!\n");
+
+  // Initial communication to wake up the sleeping slave microcontroller
+  Wire.beginTransmission(twiAddress);
+  Wire.endTransmission();
+
+  Wire.beginTransmission(twiAddress);
+  Wire.write("Testing...\r\n");
+  Wire.endTransmission();
+}

--- a/megaavr/extras/testCases/sleepUntilTWIMatch_testCase/slaveTWIMatch_testCase/slaveTWIMatch_testCase.ino
+++ b/megaavr/extras/testCases/sleepUntilTWIMatch_testCase/slaveTWIMatch_testCase/slaveTWIMatch_testCase.ino
@@ -1,0 +1,73 @@
+// Used slave_read.ino from libraries\Wire\examples\slave_read
+// in the DxCore package by MX682X for reference
+
+// Slave is AVR128DA48 Curiosity Nano board
+// Recommended baud for Serial1 is 115200
+#include <Wire.h>
+
+#define SlaveSerial Serial1
+
+unsigned long serialBaud = 115200;
+
+uint8_t sleepModeNum = 2;
+SLPCTRL_SMODE_t sleepMode = SLEEP_MODE_PWR_DOWN;
+uint8_t twiAddress = 0x08;
+bool useInternalPullups = false;
+bool flushSerial = true;
+
+unsigned long delayTime = 1000;
+bool isAwake = false;
+
+// Addresses 0x08 to 0x6F are available, the rest are for special cases found here:
+// https://github.com/cgjeffries/DxCore/tree/master/megaavr/libraries/Wire
+void setup() {
+  SlaveSerial.begin(serialBaud);
+  pickSleepMode(sleepModeNum);
+  sleepUntilTWIMatch(twiAddress, useInternalPullups, sleepMode, flushSerial);
+}
+
+void loop() {
+  delay(delayTime / 10);
+  if (isAwake) {
+    delay(delayTime);
+    isAwake = false;
+    sleepSimple(sleepMode, flushSerial);
+  }
+}
+
+void sleepUntilTWIMatch(uint8_t twiAddress, bool useInternalPullups, SLPCTRL_SMODE_t sleepMode, bool flushSerial) {
+  if (useInternalPullups) {
+    Wire.usePullups(); // Not recommended, not as reliable as exteral pullup resistors
+  }
+  Wire.begin(twiAddress);
+  Wire.onReceive(receiveFromMaster);
+  sleepSimple(sleepMode, flushSerial);
+}
+
+// This should wake the microcontroller when it's called as an event by the Wire
+void receiveFromMaster(int16_t numMasterBytes) {
+  SlaveSerial.write("Received from Master: ");
+  for (int bitPos = 0; bitPos < numMasterBytes; bitPos++) {
+    SlaveSerial.write(Wire.read());
+  }
+  if (++sleepModeNum > 2) {
+    sleepModeNum = 0;
+  }
+  pickSleepMode(sleepModeNum);
+  isAwake = true;
+}
+
+void pickSleepMode(uint8_t sleepModeNum) {
+  if (sleepModeNum == 0) {
+    SlaveSerial.write("Idle picked\n");
+    sleepMode = SLEEP_MODE_IDLE;
+  }
+  else if (sleepModeNum == 1) {
+    SlaveSerial.write("Standby picked\n");
+    sleepMode = SLEEP_MODE_STANDBY;
+  }
+  else if (sleepModeNum == 2) {
+    SlaveSerial.write("Power down picked\n");
+    sleepMode = SLEEP_MODE_PWR_DOWN;
+  }
+}


### PR DESCRIPTION
Finished the test case for MALS-110. Use the DA board as the slave and the XPlained Mini board as the master. The two .ino files will run automatically. To validate this for MALS 130, use a power debugger to draw the graph and included it in a README.md file. Also include any additional comments and changes of the scripts to the README file.

### Linked Jira Issue:
https://ser401-2022-group39.atlassian.net/jira/software/projects/MALS/boards/1?selectedIssue=MALS-110

### Description of Changes:
Added two .ino files to test sleepUntilTWIMatch with three different sleep modes.