### PR TITLE
Mals 131 analog read validate

### DIFF
--- a/megaavr/extras/testCases/analogRead/Log_Diff.txt
+++ b/megaavr/extras/testCases/analogRead/Log_Diff.txt
@@ -1,6 +1,6 @@
 double VADCREF = 1.024; // VREF;  (Set VREF in setVREF() for expected value)
-double EXTERNAL_PIN = 1.5; // POSITIVE input pin volatge
-double DAC_REF = 1.024; 
+double EXTERNAL_PIN = 1.25; // POSITIVE input pin volatge
+double DAC_REF = 2.500; 
 
 // Expected output should match those from the datasheet however outputs are about double what the expected outputs should be.
 int16_t expected_10_diff = ( (DAC_REF - EXTERNAL_PIN) / VADCREF ) * 512;
@@ -9,18 +9,18 @@ int16_t expected_12_diff = ( (DAC_REF - EXTERNAL_PIN) / VADCREF ) * 2048;
 -------------------------------------------------------------------------------------------------
 
              10 bit Differential test
-( ( 1.02 - 1.50 ) / 1.02 ) * 512 = -237
+( ( 1.25 - 2.50 ) / 2.05 ) * 512 = -312
 -------------------------------------------------------------------------------------------------
 
 sampleNum Test
-Sample Number 1  --- (Expected, Result) -> (-237, -512)
-Sample Number 2  --- (Expected, Result) -> (-474, -960)
-Sample Number 4  --- (Expected, Result) -> (-948, -1719)
-Sample Number 8  --- (Expected, Result) -> (-1896, -3129)
-Sample Number 16  --- (Expected, Result) -> (-3792, -6150)
-Sample Number 32  --- (Expected, Result) -> (-7584, -11573)
-Sample Number 64  --- (Expected, Result) -> (-15168, -22855)
-Sample Number 128  --- (Expected, Result) -> (-30336, -22690)
+Sample Number 1  --- (Expected, Result) -> (-312, 18)
+Sample Number 2  --- (Expected, Result) -> (-624, 205)
+Sample Number 4  --- (Expected, Result) -> (-1248, 749)
+Sample Number 8  --- (Expected, Result) -> (-2496, 2022)
+Sample Number 16  --- (Expected, Result) -> (-4992, 4569)
+Sample Number 32  --- (Expected, Result) -> (-9984, 9681)
+Sample Number 64  --- (Expected, Result) -> (-19968, 19888)
+Sample Number 128  --- (Expected, Result) -> (25600, 20153)
 | convMode  | muxNeg      | resolution  | prescaler   | sampleNum   | sampleDelay | sampleLen   |
 | 1         | 0           | 10          | 2           | 128         | 1           | 1           |
 -------------------------------------------------------------------------------------------------
@@ -28,18 +28,18 @@ Sample Number 128  --- (Expected, Result) -> (-30336, -22690)
 -------------------------------------------------------------------------------------------------
 
              12 bit Differential test
-( ( 1.02 - 1.50 ) / 1.02 ) * 2048 = -951
+( ( 1.25 - 2.50 ) / 2.05 ) * 2048 = -1250
 -------------------------------------------------------------------------------------------------
 
 sampleNum Test
-Sample Number 1  --- (Expected, Result) -> (-951, -2048)
-Sample Number 2  --- (Expected, Result) -> (-1902, -3829)
-Sample Number 4  --- (Expected, Result) -> (-3804, -6856)
-Sample Number 8  --- (Expected, Result) -> (-7608, -12561)
-Sample Number 16  --- (Expected, Result) -> (-15216, -23825)
-Sample Number 32  --- (Expected, Result) -> (-30432, -23188)
-Sample Number 64  --- (Expected, Result) -> (4672, -22829)
-Sample Number 128  --- (Expected, Result) -> (9344, -23427)
+Sample Number 1  --- (Expected, Result) -> (-1250, 84)
+Sample Number 2  --- (Expected, Result) -> (-2500, 838)
+Sample Number 4  --- (Expected, Result) -> (-5000, 3017)
+Sample Number 8  --- (Expected, Result) -> (-10000, 8101)
+Sample Number 16  --- (Expected, Result) -> (-20000, 18419)
+Sample Number 32  --- (Expected, Result) -> (25536, 19402)
+Sample Number 64  --- (Expected, Result) -> (-14464, 19933)
+Sample Number 128  --- (Expected, Result) -> (-28928, 20191)
 | convMode  | muxNeg      | resolution  | prescaler   | sampleNum   | sampleDelay | sampleLen   |
 | 1         | 0           | 12          | 2           | 128         | 1           | 1           |
 -------------------------------------------------------------------------------------------------

--- a/megaavr/extras/testCases/analogRead/Log_Diff.txt
+++ b/megaavr/extras/testCases/analogRead/Log_Diff.txt
@@ -1,0 +1,47 @@
+double VADCREF = 1.024; // VREF;  (Set VREF in setVREF() for expected value)
+double EXTERNAL_PIN = 1.5; // POSITIVE input pin volatge
+double DAC_REF = 1.024; 
+
+// Expected output should match those from the datasheet however outputs are about double what the expected outputs should be.
+int16_t expected_10_diff = ( (DAC_REF - EXTERNAL_PIN) / VADCREF ) * 512;
+int16_t expected_12_diff = ( (DAC_REF - EXTERNAL_PIN) / VADCREF ) * 2048; 
+
+-------------------------------------------------------------------------------------------------
+
+             10 bit Differential test
+( ( 1.02 - 1.50 ) / 1.02 ) * 512 = -237
+-------------------------------------------------------------------------------------------------
+
+sampleNum Test
+Sample Number 1  --- (Expected, Result) -> (-237, -512)
+Sample Number 2  --- (Expected, Result) -> (-474, -960)
+Sample Number 4  --- (Expected, Result) -> (-948, -1719)
+Sample Number 8  --- (Expected, Result) -> (-1896, -3129)
+Sample Number 16  --- (Expected, Result) -> (-3792, -6150)
+Sample Number 32  --- (Expected, Result) -> (-7584, -11573)
+Sample Number 64  --- (Expected, Result) -> (-15168, -22855)
+Sample Number 128  --- (Expected, Result) -> (-30336, -22690)
+| convMode  | muxNeg      | resolution  | prescaler   | sampleNum   | sampleDelay | sampleLen   |
+| 1         | 0           | 10          | 2           | 128         | 1           | 1           |
+-------------------------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------------------------
+
+             12 bit Differential test
+( ( 1.02 - 1.50 ) / 1.02 ) * 2048 = -951
+-------------------------------------------------------------------------------------------------
+
+sampleNum Test
+Sample Number 1  --- (Expected, Result) -> (-951, -2048)
+Sample Number 2  --- (Expected, Result) -> (-1902, -3829)
+Sample Number 4  --- (Expected, Result) -> (-3804, -6856)
+Sample Number 8  --- (Expected, Result) -> (-7608, -12561)
+Sample Number 16  --- (Expected, Result) -> (-15216, -23825)
+Sample Number 32  --- (Expected, Result) -> (-30432, -23188)
+Sample Number 64  --- (Expected, Result) -> (4672, -22829)
+Sample Number 128  --- (Expected, Result) -> (9344, -23427)
+| convMode  | muxNeg      | resolution  | prescaler   | sampleNum   | sampleDelay | sampleLen   |
+| 1         | 0           | 12          | 2           | 128         | 1           | 1           |
+-------------------------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------------------------

--- a/megaavr/extras/testCases/analogRead/Log_single.txt
+++ b/megaavr/extras/testCases/analogRead/Log_single.txt
@@ -1,0 +1,89 @@
+Single ended outputs behave as expected.
+
+double VADCREF = 2.048; // VREF;  (Set VREF in setVREF() for expected value)
+double EXTERNAL_PIN = 1.5; // POSITIVE input pin volatge
+
+uint16_t expected_10_single = ( EXTERNAL_PIN / VADCREF ) * 1024; 
+uint16_t expected_12_single = ( EXTERNAL_PIN / VADCREF ) * 4096; 
+
+-------------------------------------------------------------------------------------------------
+
+             10 bit Single-Ended test
+( 1.50 / 2.05 ) * 1024 = 749
+
+-------------------------------------------------------------------------------------------------
+
+prescalar Test
+Prescalar Value 2  --- (Expected, Result) -> (749, 0)
+Prescalar Value 4  --- (Expected, Result) -> (749, 767)
+Prescalar Value 8  --- (Expected, Result) -> (749, 790)
+Prescalar Value 12  --- (Expected, Result) -> (749, 786)
+Prescalar Value 16  --- (Expected, Result) -> (749, 786)
+Prescalar Value 20  --- (Expected, Result) -> (749, 789)
+Prescalar Value 24  --- (Expected, Result) -> (749, 786)
+Prescalar Value 28  --- (Expected, Result) -> (749, 783)
+Prescalar Value 32  --- (Expected, Result) -> (749, 788)
+Prescalar Value 48  --- (Expected, Result) -> (749, 786)
+Prescalar Value 64  --- (Expected, Result) -> (749, 787)
+Prescalar Value 96  --- (Expected, Result) -> (749, 787)
+Prescalar Value 128  --- (Expected, Result) -> (749, 787)
+Prescalar Value 256  --- (Expected, Result) -> (749, 788)
+-------------------------------------------------------------------------------------------------
+
+sampleDelay Test
+Sample Delay 1  --- (Expected, Result) -> (749, 767)
+Sample Delay 2  --- (Expected, Result) -> (749, 767)
+Sample Delay 3  --- (Expected, Result) -> (749, 767)
+Sample Delay 7  --- (Expected, Result) -> (749, 767)
+Sample Delay 15  --- (Expected, Result) -> (749, 767)
+Sample Delay 31  --- (Expected, Result) -> (749, 767)
+Sample Delay 63  --- (Expected, Result) -> (749, 767)
+Sample Delay 127  --- (Expected, Result) -> (749, 767)
+Sample Delay 255  --- (Expected, Result) -> (749, 767)
+Sample Delay 511  --- (Expected, Result) -> (749, 767)
+Sample Delay 1023  --- (Expected, Result) -> (749, 767)
+-------------------------------------------------------------------------------------------------
+
+sampleLen Test
+Sample Length 1  --- (Expected, Result) -> (749, 767)
+Sample Length 2  --- (Expected, Result) -> (749, 767)
+Sample Length 3  --- (Expected, Result) -> (749, 767)
+Sample Length 7  --- (Expected, Result) -> (749, 767)
+Sample Length 15  --- (Expected, Result) -> (749, 767)
+Sample Length 31  --- (Expected, Result) -> (749, 767)
+Sample Length 63  --- (Expected, Result) -> (749, 767)
+Sample Length 127  --- (Expected, Result) -> (749, 767)
+Sample Length 255  --- (Expected, Result) -> (749, 767)
+-------------------------------------------------------------------------------------------------
+
+sampleNum Test
+Sample Number 1  --- (Expected, Result) -> (749, 767)
+Sample Number 2  --- (Expected, Result) -> (1498, 1534)
+Sample Number 4  --- (Expected, Result) -> (2996, 3068)
+Sample Number 8  --- (Expected, Result) -> (5992, 6136)
+Sample Number 16  --- (Expected, Result) -> (11984, 12272)
+Sample Number 32  --- (Expected, Result) -> (23968, 24544)
+Sample Number 64  --- (Expected, Result) -> (-17600, -16448)
+Sample Number 128  --- (Expected, Result) -> (30336, -16448)
+| convMode  | muxNeg      | resolution  | prescaler   | sampleNum   | sampleDelay | sampleLen   |
+| 0         | 0           | 10          | 2           | 128         | 1           | 1           |
+-------------------------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------------------------
+
+             12 bit Single-Ended test
+( 1.50 / 2.05 ) * 4096 = 2999
+-------------------------------------------------------------------------------------------------
+
+sampleNum Test
+Sample Number 1  --- (Expected, Result) -> (2999, 3071)
+Sample Number 2  --- (Expected, Result) -> (5998, 6142)
+Sample Number 4  --- (Expected, Result) -> (11996, 12284)
+Sample Number 8  --- (Expected, Result) -> (23992, 24568)
+Sample Number 16  --- (Expected, Result) -> (-17552, -16400)
+Sample Number 32  --- (Expected, Result) -> (30432, -16400)
+Sample Number 64  --- (Expected, Result) -> (-4672, -16400)
+Sample Number 128  --- (Expected, Result) -> (-9344, -16400)
+| convMode  | muxNeg      | resolution  | prescaler   | sampleNum   | sampleDelay | sampleLen   |
+| 0         | 0           | 12          | 2           | 128         | 1           | 1           |
+-------------------------------------------------------------------------------------------------

--- a/megaavr/extras/testCases/analogRead/Log_single.txt
+++ b/megaavr/extras/testCases/analogRead/Log_single.txt
@@ -1,70 +1,62 @@
-Single ended outputs behave as expected.
-
-double VADCREF = 2.048; // VREF;  (Set VREF in setVREF() for expected value)
-double EXTERNAL_PIN = 1.5; // POSITIVE input pin volatge
-
-uint16_t expected_10_single = ( EXTERNAL_PIN / VADCREF ) * 1024; 
-uint16_t expected_12_single = ( EXTERNAL_PIN / VADCREF ) * 4096; 
-
 -------------------------------------------------------------------------------------------------
 
              10 bit Single-Ended test
-( 1.50 / 2.05 ) * 1024 = 749
+( 0.75 / 1.02 ) * 1024 = 749
 
 -------------------------------------------------------------------------------------------------
 
 prescalar Test
 Prescalar Value 2  --- (Expected, Result) -> (749, 0)
-Prescalar Value 4  --- (Expected, Result) -> (749, 767)
-Prescalar Value 8  --- (Expected, Result) -> (749, 790)
-Prescalar Value 12  --- (Expected, Result) -> (749, 786)
-Prescalar Value 16  --- (Expected, Result) -> (749, 786)
-Prescalar Value 20  --- (Expected, Result) -> (749, 789)
-Prescalar Value 24  --- (Expected, Result) -> (749, 786)
-Prescalar Value 28  --- (Expected, Result) -> (749, 783)
-Prescalar Value 32  --- (Expected, Result) -> (749, 788)
-Prescalar Value 48  --- (Expected, Result) -> (749, 786)
-Prescalar Value 64  --- (Expected, Result) -> (749, 787)
-Prescalar Value 96  --- (Expected, Result) -> (749, 787)
-Prescalar Value 128  --- (Expected, Result) -> (749, 787)
-Prescalar Value 256  --- (Expected, Result) -> (749, 788)
+Prescalar Value 4  --- (Expected, Result) -> (749, 914)
+Prescalar Value 8  --- (Expected, Result) -> (749, 911)
+Prescalar Value 12  --- (Expected, Result) -> (749, 915)
+Prescalar Value 16  --- (Expected, Result) -> (749, 915)
+Prescalar Value 20  --- (Expected, Result) -> (749, 906)
+Prescalar Value 24  --- (Expected, Result) -> (749, 915)
+Prescalar Value 28  --- (Expected, Result) -> (749, 916)
+Prescalar Value 32  --- (Expected, Result) -> (749, 909)
+Prescalar Value 48  --- (Expected, Result) -> (749, 912)
+Prescalar Value 64  --- (Expected, Result) -> (749, 914)
+Prescalar Value 96  --- (Expected, Result) -> (749, 915)
+Prescalar Value 128  --- (Expected, Result) -> (749, 912)
+Prescalar Value 256  --- (Expected, Result) -> (749, 911)
 -------------------------------------------------------------------------------------------------
 
 sampleDelay Test
-Sample Delay 1  --- (Expected, Result) -> (749, 767)
-Sample Delay 2  --- (Expected, Result) -> (749, 767)
-Sample Delay 3  --- (Expected, Result) -> (749, 767)
-Sample Delay 7  --- (Expected, Result) -> (749, 767)
-Sample Delay 15  --- (Expected, Result) -> (749, 767)
-Sample Delay 31  --- (Expected, Result) -> (749, 767)
-Sample Delay 63  --- (Expected, Result) -> (749, 767)
-Sample Delay 127  --- (Expected, Result) -> (749, 767)
-Sample Delay 255  --- (Expected, Result) -> (749, 767)
-Sample Delay 511  --- (Expected, Result) -> (749, 767)
-Sample Delay 1023  --- (Expected, Result) -> (749, 767)
+Sample Delay 1  --- (Expected, Result) -> (749, 895)
+Sample Delay 2  --- (Expected, Result) -> (749, 895)
+Sample Delay 3  --- (Expected, Result) -> (749, 895)
+Sample Delay 7  --- (Expected, Result) -> (749, 895)
+Sample Delay 15  --- (Expected, Result) -> (749, 895)
+Sample Delay 31  --- (Expected, Result) -> (749, 895)
+Sample Delay 63  --- (Expected, Result) -> (749, 895)
+Sample Delay 127  --- (Expected, Result) -> (749, 895)
+Sample Delay 255  --- (Expected, Result) -> (749, 895)
+Sample Delay 511  --- (Expected, Result) -> (749, 927)
+Sample Delay 1023  --- (Expected, Result) -> (749, 927)
 -------------------------------------------------------------------------------------------------
 
 sampleLen Test
-Sample Length 1  --- (Expected, Result) -> (749, 767)
-Sample Length 2  --- (Expected, Result) -> (749, 767)
-Sample Length 3  --- (Expected, Result) -> (749, 767)
-Sample Length 7  --- (Expected, Result) -> (749, 767)
-Sample Length 15  --- (Expected, Result) -> (749, 767)
-Sample Length 31  --- (Expected, Result) -> (749, 767)
-Sample Length 63  --- (Expected, Result) -> (749, 767)
-Sample Length 127  --- (Expected, Result) -> (749, 767)
-Sample Length 255  --- (Expected, Result) -> (749, 767)
+Sample Length 1  --- (Expected, Result) -> (749, 895)
+Sample Length 2  --- (Expected, Result) -> (749, 895)
+Sample Length 3  --- (Expected, Result) -> (749, 895)
+Sample Length 7  --- (Expected, Result) -> (749, 895)
+Sample Length 15  --- (Expected, Result) -> (749, 895)
+Sample Length 31  --- (Expected, Result) -> (749, 895)
+Sample Length 63  --- (Expected, Result) -> (749, 959)
+Sample Length 127  --- (Expected, Result) -> (749, 895)
+Sample Length 255  --- (Expected, Result) -> (749, 895)
 -------------------------------------------------------------------------------------------------
 
 sampleNum Test
-Sample Number 1  --- (Expected, Result) -> (749, 767)
-Sample Number 2  --- (Expected, Result) -> (1498, 1534)
-Sample Number 4  --- (Expected, Result) -> (2996, 3068)
-Sample Number 8  --- (Expected, Result) -> (5992, 6136)
-Sample Number 16  --- (Expected, Result) -> (11984, 12272)
-Sample Number 32  --- (Expected, Result) -> (23968, 24544)
-Sample Number 64  --- (Expected, Result) -> (-17600, -16448)
-Sample Number 128  --- (Expected, Result) -> (30336, -16448)
+Sample Number 1  --- (Expected, Result) -> (749, 895)
+Sample Number 2  --- (Expected, Result) -> (1498, 1790)
+Sample Number 4  --- (Expected, Result) -> (2996, 3580)
+Sample Number 8  --- (Expected, Result) -> (5992, 7160)
+Sample Number 16  --- (Expected, Result) -> (11984, 14320)
+Sample Number 32  --- (Expected, Result) -> (23968, 28640)
+Sample Number 64  --- (Expected, Result) -> (-17600, -8256)
+Sample Number 128  --- (Expected, Result) -> (30336, -8256)
 | convMode  | muxNeg      | resolution  | prescaler   | sampleNum   | sampleDelay | sampleLen   |
 | 0         | 0           | 10          | 2           | 128         | 1           | 1           |
 -------------------------------------------------------------------------------------------------
@@ -72,18 +64,18 @@ Sample Number 128  --- (Expected, Result) -> (30336, -16448)
 -------------------------------------------------------------------------------------------------
 
              12 bit Single-Ended test
-( 1.50 / 2.05 ) * 4096 = 2999
+( 0.75 / 1.02 ) * 4096 = 2999
 -------------------------------------------------------------------------------------------------
 
 sampleNum Test
-Sample Number 1  --- (Expected, Result) -> (2999, 3071)
-Sample Number 2  --- (Expected, Result) -> (5998, 6142)
-Sample Number 4  --- (Expected, Result) -> (11996, 12284)
-Sample Number 8  --- (Expected, Result) -> (23992, 24568)
-Sample Number 16  --- (Expected, Result) -> (-17552, -16400)
-Sample Number 32  --- (Expected, Result) -> (30432, -16400)
-Sample Number 64  --- (Expected, Result) -> (-4672, -16400)
-Sample Number 128  --- (Expected, Result) -> (-9344, -16400)
+Sample Number 1  --- (Expected, Result) -> (2999, 3583)
+Sample Number 2  --- (Expected, Result) -> (5998, 7166)
+Sample Number 4  --- (Expected, Result) -> (11996, 14332)
+Sample Number 8  --- (Expected, Result) -> (23992, 28664)
+Sample Number 16  --- (Expected, Result) -> (-17552, -8208)
+Sample Number 32  --- (Expected, Result) -> (30432, -8208)
+Sample Number 64  --- (Expected, Result) -> (-4672, -5184)
+Sample Number 128  --- (Expected, Result) -> (-9344, -8209)
 | convMode  | muxNeg      | resolution  | prescaler   | sampleNum   | sampleDelay | sampleLen   |
 | 0         | 0           | 12          | 2           | 128         | 1           | 1           |
 -------------------------------------------------------------------------------------------------

--- a/megaavr/extras/testCases/analogRead/README.md
+++ b/megaavr/extras/testCases/analogRead/README.md
@@ -1,7 +1,45 @@
-# ADC analogReadConfig Case
+# ADC analogRead 
 This test case demonstrates the verified output of analogRead function.
 
+ADC caculation for `analogRead` function provided in the data sheet is as follows;
+ - Single-ended 10-bit conversion: ( `V_AINP` / `V_ADCREF` ) * 1024; 
+ - Single-ended 12-bit conversion: ( `V_AINP` / `V_ADCREF` ) * 4096; 
+ - Differential 10-bit conversion: ( (`V_AINP` - `V_AINN`) / `V_ADCREF` ) * 512;
+ - Differential 12-bit conversion:  ( (`V_AINP` - `V_AINN`) / `V_ADCREF` ) * 2048; 
+ 
+
+For single ended `V_AINP` is the `EXTERNAL` pin `PD0`. However, for differential 
+the DAC only routes to the `MUXPOS` register (`V_AINP`), meaning the `EXTERNAL` 
+pin switches to negative (`V_AINN`) giving us the following equations;
+ - Single-ended 10-bit conversion: ( `EXTERNAL_PIN` / `V_ADCREF` ) * 1024; 
+ - Single-ended 12-bit conversion: ( `EXTERNAL_PIN` / `V_ADCREF` ) * 4096; 
+ - Differential 10-bit conversion: ( (`DAC_REF` - `EXTERNAL_PIN`) / `V_ADCREF` ) * 512;
+ - Differential 12-bit conversion:  ( (`DAC_REF` - `EXTERNAL_PIN`) / `V_ADCREF` ) * 2048;
+ 
 ## Instructions
-1. 
+1. Connect AVR128DA48 board to the signal noise generator so it is providing input
+to PD0 of the DA board.
+2. Upload the sketch to the DA board.
+3. View results in your favorite serial terminal (We used TeraTerm)
+4. Default test has `V_ADCREF` set to 1.024 and `DAC_REF` at 2.048. Modify `EXTERNAL_PIN`
+volatge (DC value of signal noise generator) to desired test value.
+	- Single-ended: Signal Noise generator should be set to DC between 0 and 1.0 V 
+	for valid readings.
+	- Differential: Signal Noise generator should be set from 1.0 V to 3.0 V (max 
+ possible output was 2.5 V for our generator) for valid output.
+5. Upload sketch and review Expected vs Result output.
 
 ## Results
+Single-ended results are within expect values. With `V_ADCREF` set to 1.024V and 
+`DAC_REF` at 2.048V the `analogRead` function produced average outputs of ~900 
+where expectd value was 749.  Expected input for `EXTERNAL` was set to 0.75V. When 
+the signal noise generator is reduced to 0.6V the expected matches the result 
+almost perfectly. 
+
+Differential results do not match predicted values. With any given setting the 
+ADC is returning a value as if the DAC is divided in half. I am unable to explain 
+or rationalize this behavior. The modified behavior is shown in the equations 
+provided.
+ - Differential 10-bit conversion: ( (`DAC_REF` - (`EXTERNAL_PIN` / 2)) / `V_ADCREF` ) * 512;
+ - Differential 12-bit conversion:  ( (`DAC_REF` - (`EXTERNAL_PIN` / 2)) / `V_ADCREF` ) * 2048;
+

--- a/megaavr/extras/testCases/analogRead/README.md
+++ b/megaavr/extras/testCases/analogRead/README.md
@@ -1,0 +1,7 @@
+# ADC analogReadConfig Case
+This test case demonstrates the verified output of analogRead function.
+
+## Instructions
+1. 
+
+## Results

--- a/megaavr/extras/testCases/analogRead/analogRead.ino
+++ b/megaavr/extras/testCases/analogRead/analogRead.ino
@@ -1,0 +1,122 @@
+/*
+  Program demonstrating analogReadConfig modifying ADC configurations.
+*/
+#define da_Serial Serial1
+
+int SINGLE_POS = A0;
+
+// 1.024, 2.048, 4.096, 2.500, 4.006 
+double VADCREF = 2.048; // VREF;  (Set VREF in setVREF() for expected value)
+double POS_VIN = 0.5; // POSITIVE input pin volatge
+// modify to match input pin voltage (ie. if VREF is 1.024v and input pin is 0.5v expected should be ~512) 
+uint16_t expected = ( POS_VIN / VADCREF ) * 1000; 
+
+void setup() {
+  da_Serial.begin(38400); // Baud rate
+}
+
+void loop() {
+    setVREF(VADCREF);
+
+    // convMode (0 = Single, 1 = Double) (default 0)
+    // muxNeg (Neg pin value for differential mode) (default 0)
+    // resolution (12-bit or 10-bit) (default 10)
+    // prescaler (2, 4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 96, 128, 256)
+    // sampleNum (1, 2, 4, 8, 16, 32, 64, 128) (default 0) result multiplier  
+    // sampleDelay (values 0-15) (default 0) 
+    // sampleLen
+
+    da_Serial.println("sampleDelay Test");
+    for (int i = 0; i <= 10; i++) {
+      sampleDelayTest(pow(2,i));
+    }
+    printSeperator();
+
+    da_Serial.println("sampleLen Test");
+    for (int i = 0; i <= 8; i++) {
+      sampleLenTest(pow(2,i));
+    }
+    printSeperator();
+  
+
+    delay(5000);
+  }
+
+
+void sampleDelayTest(int sampDelay){
+  setADC(0, 10, 10, 2, 1, sampDelay, 1);
+  da_Serial.printf("Sample Delay %d  --- (Expected, Result) -> (%d, %d)", sampDelay, expected, analogRead(SINGLE_POS));
+  da_Serial.println();
+}
+
+void sampleLenTest(int sampLen){
+  setADC(0, 10, 10, 2, 1, 1, sampLen);
+  da_Serial.printf("Sample Length %d  --- (Expected, Result) -> (%d, %d)", sampLen, expected, analogRead(SINGLE_POS));
+  da_Serial.println();
+}
+
+void setADC(int _convMode,
+            int _muxNeg,
+            int _resolution,
+            int16_t _prescaler,
+            int _sampleNum,
+            int _sampleDelay,
+            int _sampleLen){
+
+    ADCConfig modConfig = {
+      .convMode = _convMode,
+      .muxNeg = _muxNeg,
+      .resolution = _resolution,
+      .prescaler = _prescaler,
+      .sampleNum = _sampleNum,
+      .sampleDelay = _sampleDelay,
+      .sampleLen = _sampleLen 
+    };
+    analogReadConfig(modConfig);
+    //printConfigTable(getAnalogReadConfig());
+}
+
+void printConfigTable(ADCConfig config) {
+  da_Serial.printf("| %-10s| %-12s| %-12s| %-12s| %-12s| %-12s| %-12s|", 
+  "convMode","muxNeg", "resolution", "prescaler",
+  "sampleNum","sampleDelay","sampleLen");
+  da_Serial.println();
+  da_Serial.printf("| %-10d| %-12d| %-12d| %-12d| %-12d| %-12d| %-12d|", 
+  config.convMode,config.muxNeg,config.resolution,config.prescaler,
+  config.sampleNum,config.sampleDelay,config.sampleLen);
+  da_Serial.println();
+}
+
+void printSeperator() {
+  da_Serial.print("-------------------------------------------------");
+  da_Serial.println("------------------------------------------------");
+  da_Serial.println();
+}
+
+void setVREF(double ref){
+  // DxCore Refrence Voltage modes at `megaavr\extras\Ref_Analog.md`
+    /*| AVR Dx/Ex-series (all)                  | Voltage | Minimum Vdd | Mode # |
+      |-----------------------------------------|---------|-------------|--------|
+      | `VDD` (default)                         | Vcc/Vdd |             |      5 |
+      | `INTERNAL1V024`                         | 1.024 V |      2.5* V |      0 |
+      | `INTERNAL2V048`                         | 2.048 V |      2.5  V |      1 |
+      | `INTERNAL4V096`                         | 4.096 V |      4.55 V |      2 |
+      | `INTERNAL2V500`                         | 2.500 V |      2.7  V |      3 |
+      | `INTERNAL4V1` (alias of INTERNAL4V096)  | 4.006 V |      4.55 V |      2 |
+      | `EXTERNAL` (DA pin PD7)                    | VREF pin|        VREF |      6 |
+        */
+    // VREF mode (magnitude)
+    if (ref == 1.024){
+      analogReference(INTERNAL1V024);
+    } else if(ref == 2.048){
+      analogReference(INTERNAL2V048);
+    } else if(ref == 4.096){
+      analogReference(INTERNAL4V096);
+    } else if(ref == 2.500){
+      analogReference(INTERNAL2V500);
+    } else if(ref == 4.006){
+      analogReference(INTERNAL4V1);
+    } else {
+      analogReference(VDD);
+    } 
+}

--- a/megaavr/extras/testCases/analogRead/analogRead.ino
+++ b/megaavr/extras/testCases/analogRead/analogRead.ino
@@ -12,17 +12,17 @@ int RES = 10;
 int CONVMODE = 0;
 
 // 1.024, 2.048, 4.096, 2.500, 4.006 
-double VADCREF = 2.048; // VREF;  (Set VREF in setVREF() for expected value)
-double EXTERNAL_PIN = 1.5; // POSITIVE input pin volatge
-double DAC_REF = 1.024; 
+double VADCREF = 1.024; // VREF;  (Set VREF in setVREF() for expected value)
+double EXTERNAL_PIN = 1.25; // POSITIVE input pin volatge
+double DAC_REF = 2.500; 
 // modify to match input pin voltage (ie. if VREF is 1.024v and input pin is 0.5v expected should be ~512) 
 // expected = VREF / EXTERNAL_PIN
 int16_t expected = 0; 
 uint16_t expected_10_single = ( EXTERNAL_PIN / VADCREF ) * 1024; 
 uint16_t expected_12_single = ( EXTERNAL_PIN / VADCREF ) * 4096; 
-// Differential equations reversed from datasheet becuase DAC must be positive input.
-int16_t expected_10_diff = ( (DAC_REF - EXTERNAL_PIN) / VADCREF ) * 512;
-int16_t expected_12_diff = ( (DAC_REF - EXTERNAL_PIN) / VADCREF ) * 2048; 
+// Differential equations "reversed" from datasheet, DAC must be positive input, external negative.
+int16_t expected_10_diff = ( ( (EXTERNAL_PIN - DAC_REF) / VADCREF ) * 512 );
+int16_t expected_12_diff = ( ( (EXTERNAL_PIN - DAC_REF) / VADCREF ) * 2048 ); 
 
 
 void setup() {
@@ -118,6 +118,7 @@ void loop() {
     RES = 10;
     CONVMODE = 1;
     POS_PIN = DIFF_POS;
+    expected = 0;
     expected = expected_10_diff;
     printSeperator();
     da_Serial.println("             10 bit Differential test");
@@ -180,9 +181,9 @@ void print12_single(){
 }
 void print10_diff(){
   da_Serial.print("( ( ");
-  da_Serial.print(DAC_REF);
-  da_Serial.print(" - ");
   da_Serial.print(EXTERNAL_PIN);
+  da_Serial.print(" - ");
+  da_Serial.print(DAC_REF);
   da_Serial.print(" ) / ");
   da_Serial.print( VADCREF);
   da_Serial.print(" ) * 512 = ");
@@ -191,9 +192,9 @@ void print10_diff(){
 }
 void print12_diff(){
   da_Serial.print("( ( ");
-  da_Serial.print(DAC_REF);
-  da_Serial.print(" - ");
   da_Serial.print(EXTERNAL_PIN);
+  da_Serial.print(" - ");
+  da_Serial.print(DAC_REF);  
   da_Serial.print(" ) / ");
   da_Serial.print( VADCREF);
   da_Serial.print(" ) * 2048 = ");
@@ -277,23 +278,23 @@ void setDAC(double ref) {
         vref_4v096 = 0x03, // 4.096V
         vref_vdd   = 0x07, // VDD as reference
         */
-    // DAC setting (expected voltage) POSITIVE
-    Comparator.input_n = comparator::in_n::dacref;    // Connect the negative pin to the DACREF voltage
+    Comparator.input_n = comparator::in_n::dacref;
 
     if (ref == 1.024){
-      Comparator.reference = comparator::ref::vref_1v024; // Set the DACREF voltage to 2V
+      Comparator.reference = comparator::ref::vref_1v024;
     } else if(ref == 2.048){
-      Comparator.reference = comparator::ref::vref_2v048; // Set the DACREF voltage to 2V
+      da_Serial.print("REF IS 2.048");
+      Comparator.reference = comparator::ref::vref_2v048;
     } else if(ref == 2.500){
-      Comparator.reference = comparator::ref::vref_2v500; // Set the DACREF voltage to 2V
+      Comparator.reference = comparator::ref::vref_2v500;
     } else if(ref == 4.096){
-      Comparator.reference = comparator::ref::vref_4v096; // Set the DACREF voltage to 2V
+      Comparator.reference = comparator::ref::vref_4v096;
     } else {
-      Comparator.reference = comparator::ref::vref_1v024; // Set the DACREF voltage to 2V
+      Comparator.reference = comparator::ref::vref_1v024; 
     } 
     
     Comparator.init();
-    //Comparator.start();
+    Comparator.start();
 }
 
 void setVREF(double ref){

--- a/megaavr/extras/testCases/analogRead/analogRead.ino
+++ b/megaavr/extras/testCases/analogRead/analogRead.ino
@@ -1,21 +1,37 @@
 /*
   Program demonstrating analogReadConfig modifying ADC configurations.
 */
+#include <Comparator.h>
 #define da_Serial Serial1
 
 int SINGLE_POS = A0;
+int DIFF_POS = ADC_DACREF0;
+int POS_PIN = A0; //A0; // Positive pin (DAC or swap `A0;` to use external pin PD0) 
+int NEG_PIN = A0; // select the input pin NEGATIVE (PD0 -> pins-arduino.h )
+int RES = 10;
+int CONVMODE = 0;
 
 // 1.024, 2.048, 4.096, 2.500, 4.006 
 double VADCREF = 2.048; // VREF;  (Set VREF in setVREF() for expected value)
-double POS_VIN = 0.5; // POSITIVE input pin volatge
+double EXTERNAL_PIN = 1.5; // POSITIVE input pin volatge
+double DAC_REF = 1.024; 
 // modify to match input pin voltage (ie. if VREF is 1.024v and input pin is 0.5v expected should be ~512) 
-uint16_t expected = ( POS_VIN / VADCREF ) * 1000; 
+// expected = VREF / EXTERNAL_PIN
+int16_t expected = 0; 
+uint16_t expected_10_single = ( EXTERNAL_PIN / VADCREF ) * 1024; 
+uint16_t expected_12_single = ( EXTERNAL_PIN / VADCREF ) * 4096; 
+// Differential equations reversed from datasheet becuase DAC must be positive input.
+int16_t expected_10_diff = ( (DAC_REF - EXTERNAL_PIN) / VADCREF ) * 512;
+int16_t expected_12_diff = ( (DAC_REF - EXTERNAL_PIN) / VADCREF ) * 2048; 
+
 
 void setup() {
   da_Serial.begin(38400); // Baud rate
 }
 
 void loop() {
+    // Set DAC -> POSITIVE -> Magnitude of variance
+    setDAC(DAC_REF);
     setVREF(VADCREF);
 
     // convMode (0 = Single, 1 = Double) (default 0)
@@ -25,7 +41,35 @@ void loop() {
     // sampleNum (1, 2, 4, 8, 16, 32, 64, 128) (default 0) result multiplier  
     // sampleDelay (values 0-15) (default 0) 
     // sampleLen
+    RES = 10;
+    CONVMODE = 0;
+    POS_PIN = SINGLE_POS;
+    expected = expected_10_single;
+    
 
+    printSeperator();
+    da_Serial.println("             10 bit Single-Ended test");
+    print10_single();
+    da_Serial.println();
+    printSeperator();
+
+    da_Serial.println("prescalar Test");
+    prescalarTest(2);
+    prescalarTest(4);
+    prescalarTest(8);
+    prescalarTest(12);
+    prescalarTest(16);
+    prescalarTest(20);
+    prescalarTest(24);
+    prescalarTest(28);
+    prescalarTest(32);
+    prescalarTest(48);
+    prescalarTest(64);
+    prescalarTest(96);
+    prescalarTest(128);
+    prescalarTest(256);
+    printSeperator();
+  
     da_Serial.println("sampleDelay Test");
     for (int i = 0; i <= 10; i++) {
       sampleDelayTest(pow(2,i));
@@ -37,21 +81,152 @@ void loop() {
       sampleLenTest(pow(2,i));
     }
     printSeperator();
-  
+
+    da_Serial.println("sampleNum Test");
+    sampleNumTest(1);
+    sampleNumTest(2);
+    sampleNumTest(4);
+    sampleNumTest(8);
+    sampleNumTest(16);
+    sampleNumTest(32);
+    sampleNumTest(64);
+    sampleNumTest(128);
+    printConfigTable(getAnalogReadConfig());
+    printSeperator();
+
+
+    RES = 12;
+    CONVMODE = 0;
+    expected = expected_12_single;
+    printSeperator();
+    da_Serial.println("             12 bit Single-Ended test");
+    print12_single();
+    printSeperator();
+    da_Serial.println("sampleNum Test");
+    sampleNumTest(1);
+    sampleNumTest(2);
+    sampleNumTest(4);
+    sampleNumTest(8);
+    sampleNumTest(16);
+    sampleNumTest(32);
+    sampleNumTest(64);
+    sampleNumTest(128);
+
+    printConfigTable(getAnalogReadConfig());
+    printSeperator();
+
+    RES = 10;
+    CONVMODE = 1;
+    POS_PIN = DIFF_POS;
+    expected = expected_10_diff;
+    printSeperator();
+    da_Serial.println("             10 bit Differential test");
+    print10_diff();
+    printSeperator();
+    da_Serial.println("sampleNum Test");
+    sampleNumTest(1);
+    sampleNumTest(2);
+    sampleNumTest(4);
+    sampleNumTest(8);
+    sampleNumTest(16);
+    sampleNumTest(32);
+    sampleNumTest(64);
+    sampleNumTest(128);
+    printConfigTable(getAnalogReadConfig());
+    printSeperator();
+
+    RES = 12;
+    CONVMODE = 1;
+    expected = expected_12_diff;
+    printSeperator();
+    da_Serial.println("             12 bit Differential test");
+    print12_diff();
+    printSeperator();
+    da_Serial.println("sampleNum Test");
+    sampleNumTest(1);
+    sampleNumTest(2);
+    sampleNumTest(4);
+    sampleNumTest(8);
+    sampleNumTest(16);
+    sampleNumTest(32);
+    sampleNumTest(64);
+    sampleNumTest(128);
+    printConfigTable(getAnalogReadConfig());
+    printSeperator();
+
+    
 
     delay(5000);
   }
 
+// uint16_t expected_10_single = ( EXTERNAL_PIN / VADCREF ) * 1024; 
+void print10_single(){
+  da_Serial.print("( ");
+  da_Serial.print(EXTERNAL_PIN);
+  da_Serial.print(" / ");
+  da_Serial.print( VADCREF);
+  da_Serial.print(" ) * 1024 = ");
+  da_Serial.print(expected);
+  da_Serial.println();
+}
+void print12_single(){
+  da_Serial.print("( ");
+  da_Serial.print(EXTERNAL_PIN);
+  da_Serial.print(" / ");
+  da_Serial.print( VADCREF);
+  da_Serial.print(" ) * 4096 = ");
+  da_Serial.print(expected);
+  da_Serial.println();
+}
+void print10_diff(){
+  da_Serial.print("( ( ");
+  da_Serial.print(DAC_REF);
+  da_Serial.print(" - ");
+  da_Serial.print(EXTERNAL_PIN);
+  da_Serial.print(" ) / ");
+  da_Serial.print( VADCREF);
+  da_Serial.print(" ) * 512 = ");
+  da_Serial.print(expected);
+  da_Serial.println();
+}
+void print12_diff(){
+  da_Serial.print("( ( ");
+  da_Serial.print(DAC_REF);
+  da_Serial.print(" - ");
+  da_Serial.print(EXTERNAL_PIN);
+  da_Serial.print(" ) / ");
+  da_Serial.print( VADCREF);
+  da_Serial.print(" ) * 2048 = ");
+  da_Serial.print(expected);
+  da_Serial.println();
+}
+
+
+void prescalarTest(uint16_t presc){
+  setADC(CONVMODE, NEG_PIN, RES, presc, 1, 1, 1);
+  da_Serial.printf("Prescalar Value %d  --- (Expected, Result) -> (%d, %d)", presc, expected, analogRead(POS_PIN));
+  da_Serial.println();
+}
+
+void sampleNumTest(uint16_t sampNum){
+  setADC(CONVMODE, NEG_PIN, RES, 2, sampNum, 1, 1);
+  if (sampNum == 1) {
+    da_Serial.printf("Sample Number %d  --- (Expected, Result) -> (%d, %d)", sampNum, expected*sampNum, analogRead(POS_PIN));
+  } else {
+    da_Serial.printf("Sample Number %d  --- (Expected, Result) -> (%d, %d)", sampNum, expected*sampNum, analogRead(POS_PIN));
+  }
+  da_Serial.println();
+}
 
 void sampleDelayTest(int sampDelay){
-  setADC(0, 10, 10, 2, 1, sampDelay, 1);
-  da_Serial.printf("Sample Delay %d  --- (Expected, Result) -> (%d, %d)", sampDelay, expected, analogRead(SINGLE_POS));
+  setADC(CONVMODE, NEG_PIN, RES, 2, 1, sampDelay, 1);
+  da_Serial.printf("Sample Delay %d  --- (Expected, Result) -> (%d, %d)", sampDelay, expected, analogRead(POS_PIN));
   da_Serial.println();
 }
 
 void sampleLenTest(int sampLen){
-  setADC(0, 10, 10, 2, 1, 1, sampLen);
-  da_Serial.printf("Sample Length %d  --- (Expected, Result) -> (%d, %d)", sampLen, expected, analogRead(SINGLE_POS));
+  setADC(CONVMODE, NEG_PIN, RES, 2, 1, 1, sampLen);
+  da_Serial.printf("Sample Length %d  --- (Expected, Result) -> (%d, %d)", sampLen, expected, analogRead(POS_PIN));
   da_Serial.println();
 }
 
@@ -91,6 +266,34 @@ void printSeperator() {
   da_Serial.print("-------------------------------------------------");
   da_Serial.println("------------------------------------------------");
   da_Serial.println();
+}
+
+void setDAC(double ref) {
+    // DxCore Refrence Voltage modes at `megaavr\extras\Ref_Analog.md`
+    /*  vref_1v024 = 0x00, // 1.024V
+        vref_2v048 = 0x01, // 2.048V
+        vref_2v500 = 0x02, // 2.5V
+        vref_2v5   = 0x02,
+        vref_4v096 = 0x03, // 4.096V
+        vref_vdd   = 0x07, // VDD as reference
+        */
+    // DAC setting (expected voltage) POSITIVE
+    Comparator.input_n = comparator::in_n::dacref;    // Connect the negative pin to the DACREF voltage
+
+    if (ref == 1.024){
+      Comparator.reference = comparator::ref::vref_1v024; // Set the DACREF voltage to 2V
+    } else if(ref == 2.048){
+      Comparator.reference = comparator::ref::vref_2v048; // Set the DACREF voltage to 2V
+    } else if(ref == 2.500){
+      Comparator.reference = comparator::ref::vref_2v500; // Set the DACREF voltage to 2V
+    } else if(ref == 4.096){
+      Comparator.reference = comparator::ref::vref_4v096; // Set the DACREF voltage to 2V
+    } else {
+      Comparator.reference = comparator::ref::vref_1v024; // Set the DACREF voltage to 2V
+    } 
+    
+    Comparator.init();
+    //Comparator.start();
 }
 
 void setVREF(double ref){


### PR DESCRIPTION
### Linked Jira Issue:
https://ser401-2022-group39.atlassian.net/browse/MALS-131

### Description of Changes:
This sketch demonstrates the ADC being used in single ended and differential mode. Single-ended functions as expected. Exposes potential bug in differential output. Several tests produced unverifiable output from analogRead in differential mode.

### Acceptance Criteria:
- [X] AC1: analogRead returns the correct resolution of ADC reading based on the selected settings
